### PR TITLE
Converting patters to PCRE

### DIFF
--- a/blockpage_signatures.json
+++ b/blockpage_signatures.json
@@ -132,7 +132,7 @@
 {"fingerprint":"c_isp_ru_novotelecom_2","pattern":"http://zapret\.2090000\.ru"}
 {"fingerprint":"c_isp_ru_taiget","pattern":"https://hold\.taiget\.ru/block\?"}
 {"fingerprint":"c_isp_ru_divo_2","pattern":"https://www\.divo\.ru/"}
-{"fingerprint":"c_isp_ru_iterika_2","pattern":"http://iterika\.ru/blocked\.html?"}
+{"fingerprint":"c_isp_ru_iterika_2","pattern":"http://iterika\.ru/blocked\.html\?"}
 {"fingerprint":"c_isp_ru_teleseti","pattern":"http://www\.teleseti\.com/"}
 {"fingerprint":"c_isp_ru_convex","pattern":"http://ban\.convex\.ru/index\.html"}
 {"fingerprint":"c_isp_ru_rvso","pattern":"http://billing\.spb\.rsvo\.ru/blocked/blocked\.html"}

--- a/false_positive_signatures.json
+++ b/false_positive_signatures.json
@@ -64,7 +64,7 @@
 {"fingerprint":"x_fpru_not_fount_4","pattern":"<h1>Requested Website Not Found</h1>"}
 {"fingerprint":"x_fpru_weird_2","pattern":"stm-web-01"}
 {"fingerprint":"x_fpru_hvosting","pattern":"<a href=\"http://hvosting\.ua/\" target=\"_blank\" class=\"login-copy\">© HvOSTING\.UA by Nucleus</a>"}
-{"fingerprint":"x_fpru_404_4","pattern":"location\.replace(\"http://e\.busca\.uol\.com\.br/404\.html\" \+ param); </script>"}
+{"fingerprint":"x_fpru_404_4","pattern":"location\.replace\(\"http://e\.busca\.uol\.com\.br/404\.html\" \+ param\); </script>"}
 {"fingerprint":"x_fpru_php","pattern":"Your PHP installation appears to be missing the MySQL extension which is required by WordPress\."}
 {"fingerprint":"x_fpru_access","pattern":"<html><body><div align=center><h3>access denied! \(ovh-sbg\[rbx\]_2\.1\)</h3></div></body></html>"}
 {"fingerprint":"x_fpru_forpsi","pattern":"href=\"http://www\.forpsi\.com\" target=\"_parent\">"}


### PR DESCRIPTION
Patterns converted to PCRE format. The `%` bigquery wildcard is replaced by `.` or `.*` as appropriate. Other regex special characters are escaped. Some ambiguous patterns removed/edited. 