### PR TITLE
add better esight pattern

### DIFF
--- a/blockpage_signatures.json
+++ b/blockpage_signatures.json
@@ -64,7 +64,7 @@
 {"fingerprint":"a_prod_akamai_etp","pattern":"http://error\\.etp\\.akamai\\.com/error\\.html"}
 {"fingerprint":"a_prod_opendns_1","pattern":"https://block\\.opendns\\.com"}
 {"fingerprint":"a_prod_opendns_2","pattern":"https://malware\\.opendns\\.com"}
-{"fingerprint":"a_prod_huawei_esight","pattern":"The URL or page has been blocked"}
+{"fingerprint":"a_prod_huawei_esight","pattern":"Server: V2R2C00-IAE/1.0"}
 {"fingerprint":"a_prod_kerio_control","pattern":"Это сообщение создано прокси-сервером Kerio Control"}
 
 {"fingerprint":"b_nat_ir_national_1","pattern":"10\\.10\\.34\\.35"}


### PR DESCRIPTION
Replace the "The URL or page has been blocked" `a_prod_huawei_esight` pattern with "Server: V2R2C00-IAE/1.0".

That pattern is discussed in this [paper](https://public.opentech.fund/documents/English_Weber_WWW_of_Information_Controls_Final.pdf) and [here](https://www.qurium.org/alerts/internet-blocking-in-cuba-silencing-dissent-in-the-name-of-moral-and-good-manners/).

This pattern is strictly better than the existing one. It catches all existing cases, and returns a less generic blockpage for some others.
![B3FcXiQv9oPTFqu](https://user-images.githubusercontent.com/1127209/139941181-dea8a5d3-7d20-4ca2-a2c1-5c37c54b3106.png)


