### PR TITLE
Removed FP fingerprint that matches with TP cases in satellite

### DIFF
--- a/false_positive_signatures.json
+++ b/false_positive_signatures.json
@@ -238,7 +238,6 @@
 {"fingerprint":"r_fp_23","pattern":"16/index\\.html"}
 {"fingerprint":"r_fp_24","pattern":"Set-Cookie: fist_user_zz=1"}
 {"fingerprint":"r_fp_25","pattern":"121\\.201\\.80\\.216:9000"}
-{"fingerprint":"r_fp_26","pattern":"Server: nginx/1"}
 {"fingerprint":"r_fp_27","pattern":"Server: Apache-Coyote"}
 {"fingerprint":"r_fp_28","pattern":"Set-Cookie:.*domain=\\."}
 {"fingerprint":"r_fp_29","pattern":"Welcome to SCB log tracker"}


### PR DESCRIPTION
In the satellite blockpages, we see TP blockpages that matches with FP fingerprint `Server: nginx/1`.

blockpage:
```
['Content-Length: 1023', 'Content-Type: text/html', 'Date: Mon, 28 Jun 2021 01:09:33 GMT', 'Etag: "5b0e39ef-3ff"', 'Server: nginx/1.10.2']<html>
<head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
    <title>Доступ ограничен</title>
    <!-- just for RKN util:
    <title>Доступ ограничен</title>
    -->
    <style type="text/css">
        body {
            font-family: Helvetica, sans-serif;
        }
        h1 {
            font-size: 60px;
        }
        p {
            font-size: 55px;
        }
    </style>
</head>
<body>
<table border=0 width=100% height=100%>
    <tr valign=center>
        <td align=center>
            <h1>Доступ запрещён</h1><br>
<img src="http://10.0.2.90/Queries/images/logo.png">
            <p>Доступ к информационному ресурсу ограничен на основании Федерального закона от 27 июля 2006 г. N 149-ФЗ "Об информации, информационных технологиях и о защите информации"</p>
        </td>
    </tr>
</table>
</body>
</html>
```

IP: 217.27.40.122, 178.218.88.14, 5.129.186.222, 95.131.89.30...